### PR TITLE
[4.1] Fix form label relation removed title from non active elements

### DIFF
--- a/modules/mod_login/tmpl/default.php
+++ b/modules/mod_login/tmpl/default.php
@@ -37,7 +37,7 @@ Text::script('JHIDEPASSWORD');
 				<div class="input-group">
 					<input id="modlgn-username-<?php echo $module->id; ?>" type="text" name="username" class="form-control" autocomplete="username" placeholder="<?php echo Text::_('MOD_LOGIN_VALUE_USERNAME'); ?>">
 					<label for="modlgn-username-<?php echo $module->id; ?>" class="visually-hidden"><?php echo Text::_('MOD_LOGIN_VALUE_USERNAME'); ?></label>
-					<span class="input-group-text" title="<?php echo Text::_('MOD_LOGIN_VALUE_USERNAME'); ?>">
+					<span class="input-group-text">
 						<span class="icon-user icon-fw" aria-hidden="true"></span>
 					</span>
 				</div>
@@ -91,8 +91,8 @@ Text::script('JHIDEPASSWORD');
 		<?php if (PluginHelper::isEnabled('system', 'remember')) : ?>
 			<div class="mod-login__remember form-group">
 				<div id="form-login-remember-<?php echo $module->id; ?>" class="form-check">
-					<label class="form-check-label">
-						<input type="checkbox" name="remember" class="form-check-input" value="yes">
+					<label for="form-check-label">
+						<input type="checkbox" name="remember" id="form-check-label" value="yes">
 						<?php echo Text::_('MOD_LOGIN_REMEMBER_ME'); ?>
 					</label>
 				</div>


### PR DESCRIPTION
Issue:  1.Title on Non-Active Element. Which keyboard-only users and touch-only users will be unable to see the title content.
           2. A checkbox or radio button uses nesting for the label text but is missing the for/id relationship. Some screen readers will not read this correctly.

Summary of Changes: 1.Removed the title found on the non-active element.
                                     2.  Provide a matching for/id relationship between the label and the input.





